### PR TITLE
Properly finds libraries and header files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 import PackageDescription
 
 let package = Package(
-    name: "CMySQL"
+    name: "CMySQL",
+    pkgConfig: "mysqlclient"
 )

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "CMySQL",
+    pkgConfig: "mysqlclient",
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,13 +1,11 @@
 module CmySQLosx [system] {
-    header "/usr/local/include/mysql/mysql.h"
-    header "/usr/local/include/mysql/errmsg.h"
+    header "shim.h"
     link "mysqlclient"
     export *
 }
 
 module CmySQLlinux [system] {
-    header "/usr/include/mysql/mysql.h"
-    header "/usr/include/mysql/errmsg.h"
+    header "shim.h"
     link "mysqlclient"
     export *
 }

--- a/module.modulemap
+++ b/module.modulemap
@@ -9,3 +9,9 @@ module CmySQLlinux [system] {
     link "mysqlclient"
     export *
 }
+
+module CMySQL [system] {
+    header "shim.h"
+    link "mysqlclient"
+    export *
+}

--- a/shim.h
+++ b/shim.h
@@ -1,0 +1,7 @@
+#ifndef __CMYSQL_SHIM_H__
+#define __CMYSQL_SHIM_H__
+
+#include <mysql.h>
+#include <errmsg.h>
+
+#endif


### PR DESCRIPTION
- Adds `pkgConfig: "mysqlclient"` to the Package.swift, which will allow the package manager to properly find both header and library files
- Moves the imports of `errmsg.h` and `mysql.h` to a shim file to allow them to use the search paths set up by the above change.  This also makes the osx and linux modules identical, and they could be merged by a later update, though that would require an update to libraries that use the modules.