### PR TITLE
remove the need to specify compiler flags on the command line

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "CMySQL",
+    pkgConfig: "mysqlclient",
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(


### PR DESCRIPTION
By using the pkg-config support dependent modules no longer need to specify include paths on the swift command line.

I have run tests against SwiftKueryMySQL and the change works as expected.