### PR TITLE
Revert "Properly finds libraries and header files"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,5 @@
 import PackageDescription
 
 let package = Package(
-    name: "CMySQL",
-    pkgConfig: "mysqlclient"
+    name: "CMySQL"
 )

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -5,7 +5,6 @@ import PackageDescription
 
 let package = Package(
     name: "CMySQL",
-    pkgConfig: "mysqlclient",
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,17 +1,13 @@
 module CmySQLosx [system] {
-    header "shim.h"
+    header "/usr/local/include/mysql/mysql.h"
+    header "/usr/local/include/mysql/errmsg.h"
     link "mysqlclient"
     export *
 }
 
 module CmySQLlinux [system] {
-    header "shim.h"
-    link "mysqlclient"
-    export *
-}
-
-module CMySQL [system] {
-    header "shim.h"
+    header "/usr/include/mysql/mysql.h"
+    header "/usr/include/mysql/errmsg.h"
     link "mysqlclient"
     export *
 }

--- a/shim.h
+++ b/shim.h
@@ -1,7 +1,0 @@
-#ifndef __CMYSQL_SHIM_H__
-#define __CMYSQL_SHIM_H__
-
-#include <mysql.h>
-#include <errmsg.h>
-
-#endif


### PR DESCRIPTION
Reverts IBM-Swift/CMySQL#1

This is being reverted as it causes issues on Linux where the mysqlclient.pc file is not installed in a standard location. Will need to revisit the change and work out how best to fix this.