### PR TITLE
Abstract mysql types

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "CMySQL",
+    pkgConfig: "mysqlclient",
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,13 +1,5 @@
-module CmySQLosx [system] {
-    header "/usr/local/include/mysql/mysql.h"
-    header "/usr/local/include/mysql/errmsg.h"
-    link "mysqlclient"
-    export *
-}
-
-module CmySQLlinux [system] {
-    header "/usr/include/mysql/mysql.h"
-    header "/usr/include/mysql/errmsg.h"
+module CMySQL [system] {
+    header "shim.h"
     link "mysqlclient"
     export *
 }

--- a/shim.h
+++ b/shim.h
@@ -1,0 +1,42 @@
+#ifndef __CMYSQL_SHIM_H__
+#define __CMYSQL_SHIM_H__
+#include <mysql.h>
+#include <errmsg.h>
+
+#ifdef __linux__
+    #include <stdbool.h>
+    #include <stdio.h>
+#else
+    #include <Mactypes.h>
+#endif
+
+#include <mysql.h>
+#include <errmsg.h>
+
+#if LIBMYSQL_VERSION_ID < 80000
+
+  typedef my_bool mysql_bool;
+
+  static inline mysql_bool mysql_true(){
+    return 1;
+  }
+
+  static inline mysql_bool mysql_false(){
+    return 0;
+  }
+
+#else
+
+  typedef bool mysql_bool;
+
+  static inline mysql_bool mysql_true(){
+    return true;
+  }
+
+  static inline mysql_bool mysql_false(){
+    return false;
+  }
+
+#endif
+
+#endif


### PR DESCRIPTION
This PR merges individual platform libraries into a single library export.

It also adds an abstraction of mysql data types that have changed between mysql 5 and 8 including functions to set the correct values into instances of the type dependent on mysql version.

